### PR TITLE
Handle escaped commas in proof document names

### DIFF
--- a/Commander/Controllers/StandardsController.cs
+++ b/Commander/Controllers/StandardsController.cs
@@ -24,12 +24,48 @@ namespace Commander.Controllers
         }
 
         // ---------- Helpers ----------
-        private static string[] ParseProofs(string s) =>
-            (s ?? "")
-                .Split(',', StringSplitOptions.RemoveEmptyEntries)
-                .Select(p => p.Trim())
-                .Where(p => !string.IsNullOrWhiteSpace(p))
-                .ToArray();
+        private static string[] ParseProofs(string? raw)
+        {
+            if (string.IsNullOrEmpty(raw))
+                return Array.Empty<string>();
+
+            // Treat Arabic commas like English ones and support escaping via "\,"
+            raw = raw.Replace('،', ',');
+
+            var list = new List<string>();
+            var sb = new StringBuilder();
+            bool escape = false;
+
+            foreach (var ch in raw)
+            {
+                if (escape)
+                {
+                    sb.Append(ch);
+                    escape = false;
+                }
+                else if (ch == '\\')
+                {
+                    escape = true;
+                }
+                else if (ch == ',')
+                {
+                    var item = sb.ToString().Trim();
+                    if (!string.IsNullOrWhiteSpace(item))
+                        list.Add(item);
+                    sb.Clear();
+                }
+                else
+                {
+                    sb.Append(ch);
+                }
+            }
+
+            var last = sb.ToString().Trim();
+            if (!string.IsNullOrWhiteSpace(last))
+                list.Add(last);
+
+            return list.ToArray();
+        }
 
         private bool IsComplete(Standard standard)
         {

--- a/Frontend/my-app/src/components/StandardModal.jsx
+++ b/Frontend/my-app/src/components/StandardModal.jsx
@@ -25,8 +25,11 @@ export default function StandardModal({
   const [showReasons, setShowReasons] = useState(false);
 
   // ---------- helpers ----------
-  const parseProofs = (raw = '') =>
-    String(raw).replace(/،/g, ',').split(',').map(s => s.trim()).filter(Boolean);
+  const parseProofs = (raw = '') => {
+    const text = String(raw).replace(/،/g, ',');
+    const parts = text.match(/(?:\\.|[^,])+/g) || [];
+    return parts.map(s => s.replace(/\\,/g, ',').trim()).filter(Boolean);
+  };
 
   const proofs = useMemo(
     () => parseProofs(standard?.proof_required ?? standard?.Proof_required ?? ''),

--- a/Frontend/my-app/src/pages/desktop/standards/standards.js
+++ b/Frontend/my-app/src/pages/desktop/standards/standards.js
@@ -305,8 +305,11 @@ export default function Standards() {
 
   const parseProofs = (raw = '') => {
     const txt = String(raw).replace(/،/g, ',');
-    return txt.split(',').map(s => s.trim()).filter(Boolean);
+    const parts = txt.match(/(?:\\.|[^,])+/g) || [];
+    return parts.map(s => s.replace(/\\,/g, ',').trim()).filter(Boolean);
   };
+
+  const escapeCommas = (str) => String(str).replace(/[,،]/g, '\\,');
 
   // Filtering
   const filteredData = useMemo(() => {
@@ -500,7 +503,7 @@ export default function Standards() {
           standard_goal: goal,
           standard_requirments: reqs,
           assigned_department_id: depId,
-          proof_required: proofsList.join(', '),
+          proof_required: proofsList.map(p => escapeCommas(p)).join(','),
           status: 'لم يبدأ'
         };
 

--- a/Frontend/my-app/src/pages/desktop/standards_create/standards_create.js
+++ b/Frontend/my-app/src/pages/desktop/standards_create/standards_create.js
@@ -14,7 +14,7 @@ function escapeInput(str) {
   });
 }
 function escapeCommas(str) {
-  return String(str).replace(/,/g, '\\,');
+  return String(str).replace(/[,،]/g, '\\,');
 }
 // ✅ Normalize Arabic/ASCII digits & separators to ASCII ("." and 0-9)
 function normalizeStandardNumber(str = "") {

--- a/Frontend/my-app/src/pages/desktop/standards_edit/standards_edit.js
+++ b/Frontend/my-app/src/pages/desktop/standards_edit/standards_edit.js
@@ -14,7 +14,7 @@ function escapeInput(str) {
   });
 }
 function escapeCommas(str) {
-  return String(str).replace(/,/g, '\\,');
+  return String(str).replace(/[,،]/g, '\\,');
 }
 
 // ===== Helpers shared with "create" page =====
@@ -35,7 +35,8 @@ function normalizeProofTitle(s = '') {
 // Split a comma-separated list where commas may be escaped as "\,"
 function splitEscapedCommaList(str = '') {
   if (!str) return [''];
-  const parts = String(str).match(/(?:\\.|[^,])+/g) || [];
+  const normalized = String(str).replace(/،/g, ',');
+  const parts = normalized.match(/(?:\\.|[^,])+/g) || [];
   return parts.map(s => s.replace(/\\,/g, ',').trim());
 }
 


### PR DESCRIPTION
- Allow required proof lists to contain commas by supporting `\,` escaping on server and client
- Escape commas when creating, editing or importing standards so text renders correctly