### PR TITLE
Improve forgot password error handling

### DIFF
--- a/Commander/Data/SqlCommanderRepo.cs
+++ b/Commander/Data/SqlCommanderRepo.cs
@@ -62,7 +62,9 @@ namespace Commander.Data
 
         public User? GetUserByUsernameAndEmail(string username, string email)
         {
-            return _context.Users.FirstOrDefault(u => u.Username == username && u.Email == email);
+            return _context.Users.FirstOrDefault(u =>
+                u.Username.Equals(username, StringComparison.OrdinalIgnoreCase) &&
+                u.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/Frontend/my-app/src/components/ForgotPasswordModal.jsx
+++ b/Frontend/my-app/src/components/ForgotPasswordModal.jsx
@@ -33,6 +33,8 @@ export default function ForgotPasswordModal({ show, onHide, apiBase }) {
       if (res.ok) {
         setMessage('تم إرسال الرمز إلى بريدك الإلكتروني');
         setStep(2);
+      } else if (res.status === 404) {
+        setMessage('المستخدم غير موجود أو البريد الإلكتروني غير صحيح');
       } else {
         setMessage('فشل إرسال الرمز');
       }
@@ -55,6 +57,10 @@ export default function ForgotPasswordModal({ show, onHide, apiBase }) {
       if (res.ok) {
         setMessage('تم تغيير كلمة المرور');
         setTimeout(close, 1000);
+      } else if (res.status === 400) {
+        setMessage('الرمز المدخل غير صحيح');
+      } else if (res.status === 404) {
+        setMessage('المستخدم غير موجود أو البريد الإلكتروني غير صحيح');
       } else {
         setMessage('فشل إعادة التعيين');
       }


### PR DESCRIPTION
## Summary
- Search users case-insensitively when sending reset codes
- Clarify forgot-password messages for missing users and invalid codes

## Testing
- `dotnet build` *(fails: command not found)*
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689cd1d2ba9083249ea7d5a568e2e5b9