### PR TITLE
Trim username and email before lookup for password reset

### DIFF
--- a/Commander/Data/SqlCommanderRepo.cs
+++ b/Commander/Data/SqlCommanderRepo.cs
@@ -62,9 +62,12 @@ namespace Commander.Data
 
         public User? GetUserByUsernameAndEmail(string username, string email)
         {
+            var normalizedUsername = username?.Trim();
+            var normalizedEmail = email?.Trim();
+
             return _context.Users.FirstOrDefault(u =>
-                u.Username.Equals(username, StringComparison.OrdinalIgnoreCase) &&
-                u.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
+                string.Equals(u.Username, normalizedUsername, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(u.Email, normalizedEmail, StringComparison.OrdinalIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Normalize username and email input to ignore leading or trailing spaces when looking up users

## Testing
- `CI=true npm test -- --watchAll=false`
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689cd5f1dd2c8324b9d5d0d0dc1fab1d